### PR TITLE
Fix convert_to_lerobot video shape

### DIFF
--- a/scripts/convert_to_lerobot.py
+++ b/scripts/convert_to_lerobot.py
@@ -93,7 +93,7 @@ FEATURES = {
     },
     "observation.images.head_center_fisheye": {
         "dtype": "video",
-        "shape": [748, 960, 3],
+        "shape": [768, 960, 3],
         "names": ["height", "width", "channel"],
         "video_info": {
             "video.fps": 30.0,
@@ -105,7 +105,7 @@ FEATURES = {
     },
     "observation.images.head_left_fisheye": {
         "dtype": "video",
-        "shape": [748, 960, 3],
+        "shape": [768, 960, 3],
         "names": ["height", "width", "channel"],
         "video_info": {
             "video.fps": 30.0,
@@ -117,7 +117,7 @@ FEATURES = {
     },
     "observation.images.head_right_fisheye": {
         "dtype": "video",
-        "shape": [748, 960, 3],
+        "shape": [768, 960, 3],
         "names": ["height", "width", "channel"],
         "video_info": {
             "video.fps": 30.0,
@@ -129,7 +129,7 @@ FEATURES = {
     },
     "observation.images.back_left_fisheye": {
         "dtype": "video",
-        "shape": [748, 960, 3],
+        "shape": [768, 960, 3],
         "names": ["height", "width", "channel"],
         "video_info": {
             "video.fps": 30.0,
@@ -141,7 +141,7 @@ FEATURES = {
     },
     "observation.images.back_right_fisheye": {
         "dtype": "video",
-        "shape": [748, 960, 3],
+        "shape": [768, 960, 3],
         "names": ["height", "width", "channel"],
         "video_info": {
             "video.fps": 30.0,


### PR DESCRIPTION
This PR fixes the video shape from `[748, 960, 3]` to `[768, 960, 3]`, since the original video has height 768.

