### PR TITLE
Fix typo: ActionExertDecoderLayer -> ActionExpertDecoderLayer

### DIFF
--- a/go1/internvl/model/go1/modeling_action_expert.py
+++ b/go1/internvl/model/go1/modeling_action_expert.py
@@ -409,7 +409,7 @@ ACTIONEXPERT_ATTENTION_CLASSES = {
 }
 
 
-class ActionExertDecoderLayer(nn.Module):
+class ActionExpertDecoderLayer(nn.Module):
     def __init__(self, config: ActionExpertConfig):
         super().__init__()
         self.hidden_size = config.hidden_size
@@ -505,7 +505,7 @@ class ActionExpertPretrainedModel(PreTrainedModel):
     config_class = ActionExpertConfig
     base_model_prefix = "model"
     supports_gradient_checkpointing = True
-    _no_split_modules = ["ActionExertDecoderLayer"]
+    _no_split_modules = ["ActionExpertDecoderLayer"]
     _skip_keys_device_placement = "past_key_values"
     _supports_flash_attn_2 = True
 
@@ -582,7 +582,7 @@ class ActionExpertModel(ActionExpertPretrainedModel):
             self.config.attn_implementation = "eager"
             print("Warning: Flash attention is not available, using eager attention instead.")
 
-        self.layers = nn.ModuleList([ActionExertDecoderLayer(config) for _ in range(config.num_hidden_layers)])
+        self.layers = nn.ModuleList([ActionExpertDecoderLayer(config) for _ in range(config.num_hidden_layers)])
         self.norm = InternLM2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
         self.gradient_checkpointing = False

--- a/go1/internvl/model/go1/modeling_go1.py
+++ b/go1/internvl/model/go1/modeling_go1.py
@@ -111,7 +111,7 @@ class GO1Model(PreTrainedModel):
     _no_split_modules = [
         "InternVisionModel",
         "InternLM2DecoderLayerGO1",
-        "ActionExertDecoderLayer",
+        "ActionExpertDecoderLayer",
     ]
     _supports_flash_attn_2 = True
 


### PR DESCRIPTION
# Description
Correct a typo in the class name: "ActionExertDecoderLayer" → "ActionExpertDecoderLayer"
This typo may cause confusion for developers when importing or understanding the module, and fixing it ensures naming consistency.

# Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

# How Has This Been Tested?
- Checked that the modified code can be imported normally (no ImportError)
- Confirmed that the class name is consistent with other related modules (e.g., ActionExpertModel)

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] No dependent changes are required